### PR TITLE
Change Connection string to the new tenant 

### DIFF
--- a/src/Core/Logistics.Infrastructure/Services/TenantDatabaseService.cs
+++ b/src/Core/Logistics.Infrastructure/Services/TenantDatabaseService.cs
@@ -48,6 +48,7 @@ public class TenantDatabaseService : ITenantDatabaseService
     {
         try
         {
+            _context.Database.SetConnectionString(connectionString);
             await _context.Database.MigrateAsync();
             await AddTenantRoles();
             return true;


### PR DESCRIPTION
This pull request introduces a minor update to the `TenantDatabaseService` by ensuring that the database connection string is explicitly set before running migrations. This change improves reliability when creating a new tenant database.

* Set the connection string on `_context.Database` using `SetConnectionString` before calling `MigrateAsync` in `CreateDatabaseAsync`, ensuring the correct database context is used for migrations.